### PR TITLE
fix: remove pil opt

### DIFF
--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -214,7 +214,7 @@ fn compile<T: FieldElement, Q: QueryCallback<T>>(
     external_witness_values: Vec<(&str, Vec<T>)>,
 ) -> CompilationResult<T> {
     log::info!("Optimizing pil...");
-    let analyzed = pilopt::optimize(analyzed);
+    // let analyzed = pilopt::optimize(analyzed);
     let optimized_pil_file_name = output_dir.join(format!(
         "{}_opt.pil",
         Path::new(file_name).file_stem().unwrap().to_str().unwrap()


### PR DESCRIPTION
As title, the optimised compiled version removes columns based on the circuit being verified, as we want a general circuit for all inputs, we do not want to have this optimisation pass present, as it will remove some expressions / columns that we want to keep