### PR TITLE
feat: bberg pil only binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,6 +588,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "bberg_bin_cli"
+version = "0.1.0"
+dependencies = [
+ "acvm",
+ "analysis 0.1.0",
+ "asm_utils",
+ "ast 0.1.0",
+ "base64 0.10.1",
+ "clap 4.4.6",
+ "compiler",
+ "env_logger",
+ "executor",
+ "importer",
+ "itertools 0.10.5",
+ "linker",
+ "log",
+ "num-bigint 0.4.4",
+ "num-integer",
+ "num-traits",
+ "number 0.1.0",
+ "parser 0.1.0",
+ "pil_analyzer 0.1.0",
+ "rand 0.8.5",
+ "test-log",
+]
+
+[[package]]
 name = "bellman_ce"
 version = "0.3.2"
 source = "git+https://github.com/matter-labs/bellman?branch=beta#416f79d3f93fc855fb96bb61bfe73d2472e95548"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "halo2",
     "backend",
     "bberg",
+    "bberg_pil_cli",
     "ast",
     "analysis",
     "linker",

--- a/bberg_pil_cli/Cargo.toml
+++ b/bberg_pil_cli/Cargo.toml
@@ -1,0 +1,42 @@
+
+[package]
+name = "bberg_bin_cli"
+version = "0.1.0"
+authors = ["Maddiaa"]
+edition = "2021"
+
+[[bin]]
+name = "bberg_pil"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "^4.3", features = ["derive"] }
+asm_utils = { path = "../asm_utils" }
+compiler = { path = "../compiler" }
+num-bigint = "0.4.3"
+
+number = { path = "../number" }
+pil_analyzer = { path = "../pil_analyzer" }
+num-traits = "0.2.15"
+num-integer = "0.1.45"
+itertools = "^0.10"
+log = "0.4.17"
+rand = "0.8.5"
+ast = { version = "0.1.0", path = "../ast" }
+
+
+# TODO: we probably want to pull in the local version of nargo while i am working on it here
+
+# Include acvm brillig module such that we can serialise and deserialise them
+acvm = { git = "https://github.com/noir-lang/noir",  directory = "acvm-repo/acvm" }
+base64 = "*"
+
+[dev-dependencies]
+importer = { path = "../importer" }
+analysis = { path = "../analysis" }
+executor = { path = "../executor" }
+parser = { path = "../parser" }
+test-log = "0.2.12"
+env_logger = "0.10.0"
+linker = { path = "../linker" }
+

--- a/bberg_pil_cli/README.md
+++ b/bberg_pil_cli/README.md
@@ -1,0 +1,3 @@
+## BBERG PIL CLI
+A small wrapper around powdr pil that only implements the parts of powdr required for direct pil -> bberg codegen
+

--- a/bberg_pil_cli/src/main.rs
+++ b/bberg_pil_cli/src/main.rs
@@ -1,0 +1,42 @@
+use std::{io, path::Path};
+
+use clap::Parser;
+use compiler::{compile_pil, inputs_to_query_callback, BackendType};
+use number::Bn254Field;
+
+#[derive(Parser)]
+#[command(name = "bberg_pil", author, version, about, long_about = None)]
+struct Cli {
+    /// Input file
+    file: String,
+
+    /// Output directory for the PIL file, json file and fixed and witness column data.
+    #[arg(short, long)]
+    #[arg(default_value_t = String::from("."))]
+    output_directory: String,
+
+    /// BBerg: Name of the output file for bberg
+    #[arg(long)]
+    name: Option<String>,
+}
+
+fn main() -> Result<(), io::Error> {
+    let args = Cli::parse();
+
+    let file_name = args.file;
+    let output_dir = Path::new(&args.output_directory);
+    let name = args.name;
+    let inputs: Vec<Bn254Field> = Vec::new();
+    let prove_with = Some(BackendType::BBerg);
+    let external_witness_values = Vec::new();
+
+    compile_pil(
+        Path::new(&file_name),
+        output_dir,
+        inputs_to_query_callback(inputs),
+        prove_with,
+        external_witness_values,
+        name,
+    );
+    Ok(())
+}

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -267,7 +267,7 @@ fn compile<T: FieldElement, Q: QueryCallback<T>>(
             &constants,
             &witness_in_powdr_form,
             None,
-            None,
+            bname,
         );
     }
 

--- a/test_data/pil/fibonacci.pil
+++ b/test_data/pil/fibonacci.pil
@@ -3,18 +3,21 @@ constant %N = 16;
 // This uses the alternative nomenclature as well.
 
 namespace Fibonacci(%N);
-    col fixed ISLAST(i) { match i {
+    col fixed LAST(i) { match i {
         %N - 1 => 1,
-        0 => 1, // also added is last at the beginning to make the empty shifts work
+        _ => 0,
+    } };
+    col fixed FIRST(i) { match i {
+        0 => 1,
         _ => 0,
     } };
     col witness x, y;
 
-    ISLAST * (y' - 1) = 0;
-    ISLAST * (x' - 1) = 0;
+    LAST * (y' - 1) = 0;
+    LAST * (x' - 1) = 0;
 
-    (1-ISLAST) * (x' - y) = 0;
-    (1-ISLAST) * (y' - (x + y)) = 0;
+    (1-LAST) * (x' - y) = 0;
+    (1-LAST) * (y' - (x + y)) = 0;
 
 
     public out = y(%N-1);


### PR DESCRIPTION
```bash
bberg_pil <filename>
```

Creates a pil compiler binary that ONLY requires giving a filename, this prefills the field type and the chosen backend, this will reduce the overhead required by aztec devs