### PR TITLE
fix: remove FIRST and LAST requirement

### DIFF
--- a/bberg/src/circuit_builder.rs
+++ b/bberg/src/circuit_builder.rs
@@ -35,25 +35,10 @@ pub(crate) fn analyzed_to_cpp<F: FieldElement>(
         .map(|(name, _)| (*name).to_owned())
         .collect::<Vec<_>>();
 
-    let first_col = fixed
-        .iter()
-        .find(|col_name| col_name.0.contains("FIRST"))
-        .expect("PIL file must contain a fixed column named FIRST")
-        .0
-        .replace('.', "_");
-
-    let last_col = fixed
-        .iter()
-        .find(|col_name| col_name.0.contains("LAST"))
-        .expect("PIL file must contain a fixed column named LAST")
-        .0
-        .replace('.', "_");
-
     // Inlining step to remove the intermediate poly definitions
     let analyzed_identities = inline_intermediate_polynomials(analyzed);
 
-    let (subrelations, identities, mut collected_shifts) =
-        create_identities(&first_col, &last_col, &analyzed_identities);
+    let (subrelations, identities, mut collected_shifts) = create_identities(&analyzed_identities);
     let shifted_polys: Vec<String> = collected_shifts.drain().collect_vec();
 
     let (all_cols, unshifted, to_be_shifted, _shifted, all_cols_with_shifts) =

--- a/bberg/src/relation_builder.rs
+++ b/bberg/src/relation_builder.rs
@@ -181,14 +181,13 @@ fn get_cols_in_identity_macro(all_rows_and_shifts: &[String]) -> String {
 }
 
 fn create_identity<T: FieldElement>(
-    last_col: &str,
     expression: &SelectedExpressions<Expression<T>>,
     collected_shifts: &mut HashSet<String>,
 ) -> Option<BBIdentity> {
     // We want to read the types of operators and then create the appropiate code
 
     if let Some(expr) = &expression.selector {
-        let x = craft_expression(last_col, expr, collected_shifts);
+        let x = craft_expression(expr, collected_shifts);
         println!("{:?}", x);
         Some(x)
     } else {
@@ -197,12 +196,7 @@ fn create_identity<T: FieldElement>(
 }
 
 // TODO: replace the preamble with a macro so the code looks nicer
-fn create_subrelation(
-    first_col: &str,
-    index: usize,
-    preamble: String,
-    identity: &mut BBIdentity,
-) -> String {
+fn create_subrelation(index: usize, preamble: String, identity: &mut BBIdentity) -> String {
     // \\\
     let id = &identity.1;
 
@@ -218,7 +212,6 @@ fn create_subrelation(
 }
 
 fn craft_expression<T: FieldElement>(
-    last_col: &str,
     expr: &Expression<T>,
     collected_shifts: &mut HashSet<String>,
 ) -> BBIdentity {
@@ -234,14 +227,14 @@ fn craft_expression<T: FieldElement>(
                 poly_name = format!("{}_shift", poly_name);
 
                 // TODO(HORRIBLE): TEMP, add in a relation that turns off shifts on the last row
-                poly_name = format!("{poly_name} * (-{} + FF(1))", last_col);
+                poly_name = format!("{poly_name}");
                 degree += 1;
             }
             (degree, poly_name)
         }
         Expression::BinaryOperation(lhe, op, rhe) => {
-            let (ld, lhs) = craft_expression(last_col, lhe, collected_shifts);
-            let (rd, rhs) = craft_expression(last_col, rhe, collected_shifts);
+            let (ld, lhs) = craft_expression(lhe, collected_shifts);
+            let (rd, rhs) = craft_expression(rhe, collected_shifts);
 
             // dbg!(&lhe);
             let degree = std::cmp::max(ld, rd);
@@ -267,7 +260,7 @@ fn craft_expression<T: FieldElement>(
         // }
         Expression::UnaryOperation(operator, expression) => match operator {
             AlgebraicUnaryOperator::Minus => {
-                let (d, e) = craft_expression(last_col, expression, collected_shifts);
+                let (d, e) = craft_expression(expression, collected_shifts);
                 (d, format!("-{}", e))
             }
             _ => unimplemented!("{:?}", expr),
@@ -279,8 +272,6 @@ fn craft_expression<T: FieldElement>(
 
 /// Todo, eventually these will need to be siloed based on the file name they are in
 pub(crate) fn create_identities<F: FieldElement>(
-    first_col: &str,
-    last_col: &str,
     identities: &Vec<Identity<Expression<F>>>,
 ) -> (Vec<String>, Vec<BBIdentity>, HashSet<String>) {
     // We only want the expressions for now
@@ -307,8 +298,8 @@ pub(crate) fn create_identities<F: FieldElement>(
         );
         // TODO: deal with unwrap
 
-        let mut identity = create_identity(last_col, expression, &mut collected_shifts).unwrap();
-        let subrelation = create_subrelation(first_col, i, relation_boilerplate, &mut identity);
+        let mut identity = create_identity(expression, &mut collected_shifts).unwrap();
+        let subrelation = create_subrelation(i, relation_boilerplate, &mut identity);
 
         identities.push(identity);
 

--- a/bberg/src/relation_builder.rs
+++ b/bberg/src/relation_builder.rs
@@ -206,15 +206,12 @@ fn create_subrelation(
     // \\\
     let id = &identity.1;
 
-    // TODO: TEMP HACK: Part of the main_FIRST hack below - to switch off constraints on the first row
-    identity.0 += 1;
     format!(
         "//Contribution {index}
     {{\n{preamble}
     
     auto tmp = {id};
     tmp *= scaling_factor;
-    tmp *= (-{first_col} + FF(1)); // Temp to switch off 
     std::get<{index}>(evals) += tmp;
 }}",
     )
@@ -321,9 +318,3 @@ pub(crate) fn create_identities<F: FieldElement>(
     // Returning both for now
     (subrelations, identities, collected_shifts)
 }
-
-//
-//    Row check_row = { .main_FIRST = 1, .main__block_enforcer_last_step = 1, .main_XIsZero = 1 };
-// rows.push_back(check_row);
-//
-//

--- a/bberg/src/trace_builder.rs
+++ b/bberg/src/trace_builder.rs
@@ -9,28 +9,6 @@ pub trait TraceBuilder {
     ) -> String;
 }
 
-fn trace_cpp_includes(relation_path: &str, name: &str) -> String {
-    let boilerplate = r#"
-#include "barretenberg/ecc/curves/bn254/fr.hpp"
-#include <cstdint>
-#include <fstream>
-#include <iostream>
-#include <string>
-#include <sys/types.h>
-#include <vector>
-#include "barretenberg/proof_system/arithmetization/arithmetization.hpp"
-"#
-    .to_owned();
-
-    format!(
-        "
-{boilerplate}
-#include \"barretenberg/{relation_path}/{name}.hpp\"
-#include \"barretenberg/proof_system/arithmetization/generated/{name}_arith.hpp\"
-"
-    )
-}
-
 fn trace_hpp_includes(name: &str) -> String {
     format!(
         "

--- a/bberg/src/trace_builder.rs
+++ b/bberg/src/trace_builder.rs
@@ -1,12 +1,7 @@
 use crate::file_writer::BBFiles;
 
 pub trait TraceBuilder {
-    fn create_trace_builder_hpp(
-        &mut self,
-        name: &str,
-        fixed: &[String],
-        shifted: &[String],
-    ) -> String;
+    fn create_trace_builder_hpp(&mut self, name: &str, fixed: &[String], shifted: &[String]);
 }
 
 fn trace_hpp_includes(name: &str) -> String {
@@ -35,7 +30,7 @@ impl TraceBuilder for BBFiles {
         name: &str,
         all_cols: &[String],
         to_be_shifted: &[String],
-    ) -> String {
+    ) {
         let includes = trace_hpp_includes(name);
 
         let num_polys = all_cols.len();
@@ -53,7 +48,7 @@ impl TraceBuilder for BBFiles {
             .collect::<Vec<String>>()
             .join("\n");
 
-        format!("
+        let trace_hpp = format!("
 {includes}
 
 using namespace barretenberg;
@@ -137,6 +132,7 @@ class {name}TraceBuilder {{
 
 }};
 }}
-        ")
+        ");
+        self.trace_hpp = Some(trace_hpp);
     }
 }


### PR DESCRIPTION
Removes codegen hacks that implicitly include LAST and FIRST in relations 