### PR TITLE
Align namespaces with simplification performed in Barretenberg

### DIFF
--- a/bberg/src/circuit_builder.rs
+++ b/bberg/src/circuit_builder.rs
@@ -89,7 +89,7 @@ impl CircuitBuilder for BBFiles {
         };
         let check_lookup_transformation = |lookup_name: &String| {
             format!(
-                    "if (!evaluate_logderivative.template operator()<honk::{lookup_name}_relation<FF>>(\"{lookup_name}\")) {{
+                    "if (!evaluate_logderivative.template operator()<{lookup_name}_relation<FF>>(\"{lookup_name}\")) {{
                         return false;
                     }}"
                 )
@@ -116,8 +116,6 @@ impl CircuitBuilder for BBFiles {
 
         let circuit_hpp = format!("
 {includes}
-
-using namespace bb;
 
 namespace bb {{
 
@@ -204,7 +202,7 @@ fn get_lookup_check_closure() -> String {
             const auto evaluate_logderivative = [&]<typename LogDerivativeSettings>(const std::string& lookup_name) {
 
                 // Check the logderivative relation
-                bb::logderivative_library::compute_logderivative_inverse<
+                bb::compute_logderivative_inverse<
                     Flavor,
                     LogDerivativeSettings>(
                     polys, params, num_rows);

--- a/bberg/src/lookup_builder.rs
+++ b/bberg/src/lookup_builder.rs
@@ -203,7 +203,7 @@ fn create_lookup_settings_file(lookup: &Lookup) -> String {
         "
         {lookup_settings_includes}
 
-        namespace bb::sumcheck {{
+        namespace bb {{
 
         /**
          * @brief This class contains an example of how to set LookupSettings classes used by the

--- a/bberg/src/permutation_builder.rs
+++ b/bberg/src/permutation_builder.rs
@@ -163,7 +163,7 @@ fn create_permutation_settings_file(permutation: &Permutation) -> String {
         "
         {permutation_settings_includes}
 
-        namespace bb::sumcheck {{
+        namespace bb {{
 
         class {permutation_name}_permutation_settings {{
             public:


### PR DESCRIPTION
The following nested namespaces have been removed:

- sumcheck
- honk
- logderivative_library