### PR TITLE
Support specifying column index in public input declaration

### DIFF
--- a/asm_to_pil/src/vm_to_constrained.rs
+++ b/asm_to_pil/src/vm_to_constrained.rs
@@ -313,7 +313,7 @@ impl<T: FieldElement> ASMPILConverter<T> {
                 ty,
             },
         );
-        self.pil.push(witness_column(start, name, None, false));
+        self.pil.push(witness_column(start, name, None, None));
     }
 
     fn handle_instruction_def(
@@ -846,7 +846,7 @@ impl<T: FieldElement> ASMPILConverter<T> {
                         ),
                     )
                 });
-                witness_column(0, free_value, prover_query, false)
+                witness_column(0, free_value, prover_query, None)
             })
             .collect::<Vec<_>>();
         self.pil.extend(free_value_pil);
@@ -877,7 +877,7 @@ impl<T: FieldElement> ASMPILConverter<T> {
     /// Creates a pair of witness and fixed column and matches them in the lookup.
     fn create_witness_fixed_pair(&mut self, start: usize, name: &str) {
         let fixed_name = format!("p_{name}");
-        self.pil.push(witness_column(start, name, None, false));
+        self.pil.push(witness_column(start, name, None, None));
         self.line_lookup
             .push((name.to_string(), fixed_name.clone()));
         self.rom_constant_names.push(fixed_name);
@@ -1082,7 +1082,7 @@ fn witness_column<S: Into<String>, T>(
     start: usize,
     name: S,
     def: Option<FunctionDefinition<T>>,
-    is_public: bool,
+    public_info: Option<usize>,
 ) -> PilStatement<T> {
     PilStatement::PolynomialCommitDeclaration(
         start,
@@ -1091,7 +1091,7 @@ fn witness_column<S: Into<String>, T>(
             array_size: None,
         }],
         def,
-        is_public,
+        public_info,
     )
 }
 

--- a/ast/src/analyzed/display.rs
+++ b/ast/src/analyzed/display.rs
@@ -96,6 +96,9 @@ impl<T: Display> Display for Analyzed<T> {
 impl<T: Display> Display for FunctionValueDefinition<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
+            FunctionValueDefinition::Number(n) => {
+                write!(f, "{}", n)
+            }
             FunctionValueDefinition::Array(items) => {
                 write!(f, " = {}", items.iter().format(" + "))
             }

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -290,6 +290,7 @@ impl<T> Analyzed<T> {
                     .flat_map(|e| e.pattern.iter_mut())
                     .for_each(|e| e.post_visit_expressions_mut(f)),
                 Some(FunctionValueDefinition::Expression(e)) => e.post_visit_expressions_mut(f),
+                Some(FunctionValueDefinition::Number(_)) => {}
                 None => {}
             });
     }
@@ -446,6 +447,7 @@ pub enum FunctionValueDefinition<T> {
     Array(Vec<RepeatedArray<T>>),
     Query(Expression<T>),
     Expression(Expression<T>),
+    Number(usize),
 }
 
 /// An array of elements that might be repeated.

--- a/ast/src/analyzed/visitor.rs
+++ b/ast/src/analyzed/visitor.rs
@@ -93,6 +93,7 @@ impl<T> ExpressionVisitable<Expression<T>> for FunctionValueDefinition<T> {
                 .iter_mut()
                 .flat_map(|a| a.pattern.iter_mut())
                 .try_for_each(move |item| item.visit_expressions_mut(f, o)),
+            FunctionValueDefinition::Number(_) => ControlFlow::Continue(()),
         }
     }
 
@@ -108,6 +109,7 @@ impl<T> ExpressionVisitable<Expression<T>> for FunctionValueDefinition<T> {
                 .iter()
                 .flat_map(|a| a.pattern().iter())
                 .try_for_each(move |item| item.visit_expressions(f, o)),
+            FunctionValueDefinition::Number(_) => ControlFlow::Continue(()),
         }
     }
 }

--- a/ast/src/parsed/display.rs
+++ b/ast/src/parsed/display.rs
@@ -379,7 +379,11 @@ impl<T: Display> Display for PilStatement<T> {
                 write!(
                     f,
                     "pol commit {}{}{};",
-                    if *public { "public " } else { " " },
+                    if let Some(n) = public {
+                        format!("public : {n}")
+                    } else {
+                        " ".to_string()
+                    },
                     names.iter().format(", "),
                     value.as_ref().map(|v| format!("{v}")).unwrap_or_default(),
                 )
@@ -431,6 +435,9 @@ impl<T: Display> Display for ArrayExpression<T> {
 impl<T: Display> Display for FunctionDefinition<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         match self {
+            FunctionDefinition::Number(n) => {
+                write!(f, "{n}")
+            }
             FunctionDefinition::Array(array_expression) => {
                 write!(f, " = {array_expression}")
             }

--- a/ast/src/parsed/mod.rs
+++ b/ast/src/parsed/mod.rs
@@ -37,7 +37,7 @@ pub enum PilStatement<T> {
         usize,
         Vec<PolynomialName<T>>,
         Option<FunctionDefinition<T>>,
-        /*public=*/ bool,
+        Option<usize>,
     ),
     PolynomialIdentity(usize, Option<String>, Expression<T>),
     PlookupIdentity(
@@ -82,6 +82,7 @@ pub enum Expression<T, Ref = NamespacedPolynomialReference> {
     Reference(Ref),
     PublicReference(String),
     Number(T),
+    // LiteralNumber(usize),
     String(String),
     Tuple(Vec<Expression<T, Ref>>),
     LambdaExpression(LambdaExpression<T, Ref>),
@@ -270,6 +271,8 @@ pub enum FunctionDefinition<T> {
     Query(Vec<String>, Expression<T>),
     /// Generic expression
     Expression(Expression<T>),
+    /// Constant for public inputs
+    Number(usize),
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]

--- a/ast/src/parsed/visitor.rs
+++ b/ast/src/parsed/visitor.rs
@@ -304,6 +304,7 @@ impl<T> ExpressionVisitable<Expression<T>> for FunctionDefinition<T> {
             FunctionDefinition::Query(_, e) => e.visit_expressions_mut(f, o),
             FunctionDefinition::Array(ae) => ae.visit_expressions_mut(f, o),
             FunctionDefinition::Expression(e) => e.visit_expressions_mut(f, o),
+            FunctionDefinition::Number(_) => ControlFlow::Continue(()),
         }
     }
 
@@ -315,6 +316,7 @@ impl<T> ExpressionVisitable<Expression<T>> for FunctionDefinition<T> {
             FunctionDefinition::Query(_, e) => e.visit_expressions(f, o),
             FunctionDefinition::Array(ae) => ae.visit_expressions(f, o),
             FunctionDefinition::Expression(e) => e.visit_expressions(f, o),
+            FunctionDefinition::Number(_) => ControlFlow::Continue(()),
         }
     }
 }

--- a/bberg/src/bberg_codegen.rs
+++ b/bberg/src/bberg_codegen.rs
@@ -22,7 +22,7 @@ impl BBergCodegen {
     }
 
     pub fn new_from_setup(_input: &mut impl io::Read) -> Result<Self, io::Error> {
-        println!("warning bberg: new_from_setup not implemented");
+        log::warn!("warning bberg: new_from_setup not implemented");
         Ok(Self {})
     }
 

--- a/bberg/src/permutation_builder.rs
+++ b/bberg/src/permutation_builder.rs
@@ -120,7 +120,7 @@ fn permutation_settings_includes() -> &'static str {
 }
 
 fn create_permutation_settings_file(permutation: &Permutation) -> String {
-    println!("Permutation: {:?}", permutation);
+    log::trace!("Permutation: {:?}", permutation);
     let columns_per_set = permutation.left.cols.len();
     // TODO(md): In the future we will need to condense off the back of this - combining those with the same inverse column
     let permutation_name = permutation

--- a/bberg/src/relation_builder.rs
+++ b/bberg/src/relation_builder.rs
@@ -306,7 +306,7 @@ fn create_identity<T: FieldElement>(
 
     if let Some(expr) = &expression.selector {
         let x = craft_expression(expr, collected_cols, collected_public_identities);
-        println!("{:?}", x);
+        log::trace!("expression {:?}", x);
         Some(x)
     } else {
         None
@@ -464,8 +464,10 @@ pub(crate) fn create_identities<F: FieldElement>(
 
     // Print a warning to the user about usage of public identities
     if !collected_public_identities.is_empty() {
-        println!("Public Identities are not supported yet in codegen, however some were collected");
-        println!("Public Identities: {:?}", collected_public_identities);
+        log::warn!(
+            "Public Identities are not supported yet in codegen, however some were collected"
+        );
+        log::warn!("Public Identities: {:?}", collected_public_identities);
     }
 
     let mut collected_cols: Vec<String> = collected_cols.drain().collect();

--- a/executor/src/constant_evaluator/mod.rs
+++ b/executor/src/constant_evaluator/mod.rs
@@ -36,6 +36,7 @@ fn generate_values<T: FieldElement>(
     };
     // TODO we should maybe pre-compute some symbols here.
     match body {
+        FunctionValueDefinition::Number(n) => vec![T::from(*n as u64)],
         FunctionValueDefinition::Expression(e) => (0..degree)
             .into_par_iter()
             .map(|i| {

--- a/parser/src/powdr.lalrpop
+++ b/parser/src/powdr.lalrpop
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 use ast::parsed::{*, asm::*};
 use number::{AbstractNumberType, FieldElement};
-use num_traits::Num;
+use num_traits::{Num, ToPrimitive};
 
 grammar<T> where T: FieldElement;
 
@@ -122,10 +122,10 @@ ArrayLiteralTerm: ArrayExpression<T> = {
 }
 
 PolynomialCommitDeclaration: PilStatement<T> = {
-    <@L> PolCol CommitWitness <PolynomialNameList> => PilStatement::PolynomialCommitDeclaration(<>, None, false),
-    <@L> PolCol "public" <PolynomialNameList> => PilStatement::PolynomialCommitDeclaration(<>, None, true),
+    <@L> PolCol CommitWitness <PolynomialNameList> => PilStatement::PolynomialCommitDeclaration(<>, None, None),
+    <start:@L> PolCol "public" "(" <n:Integer> ")" <name:PolynomialName> => PilStatement::PolynomialCommitDeclaration(start, vec![name], None, Some(n.to_usize().unwrap())),
     <start:@L> PolCol CommitWitness <name:PolynomialName> "(" <param:ParameterList> ")" "query" <value:Expression>
-     => PilStatement::PolynomialCommitDeclaration(start, vec![name], Some(FunctionDefinition::Query(param, value)), false)
+     => PilStatement::PolynomialCommitDeclaration(start, vec![name], Some(FunctionDefinition::Query(param, value)), None)
 }
 
 PolynomialIdentity: PilStatement<T> = {

--- a/pilopt/src/lib.rs
+++ b/pilopt/src/lib.rs
@@ -80,6 +80,7 @@ fn constant_value<T: FieldElement>(function: &FunctionValueDefinition<T>) -> Opt
         }
         FunctionValueDefinition::Query(_) => None,
         FunctionValueDefinition::Expression(_) => None,
+        FunctionValueDefinition::Number(_) => None,
     }
 }
 


### PR DESCRIPTION
```
pol public(/*idx=*/0) kernel_inputs;
pol public(/*idx=*/1) kernel_value_out;
pol public(/*idx=*/2) kernel_side_effect_out;
pol public(/*idx=*/3) kernel_metadata_out;
```

and the verifier is now correctly generated.