### PR TITLE
Docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For detailed documentation please visit [the powdr book](https://docs.powdr.org/
 It has two main components:
 
 - powdr-asm: an extensible assembly IR language to perform dynamic executions.
-- powdr-PIL: a low level constraint language that allows you to define arithmetic constraints, lookups, etc.
+- powdr-PIL: a low-level constraint language that allows you to define arithmetic constraints, lookups, etc.
   
 Both frontend and backend are highly flexible.
 

--- a/airgen/src/lib.rs
+++ b/airgen/src/lib.rs
@@ -163,7 +163,7 @@ impl<'a, T: FieldElement> ASMPILConverter<'a, T> {
             flag: flag.clone(),
         };
 
-        // get the machine type name for this submachine from the submachine delcarations
+        // get the machine type name for this submachine from the submachine declarations
         let instance_ty_name = self
             .submachines
             .iter()

--- a/analysis/README.md
+++ b/analysis/README.md
@@ -68,11 +68,11 @@ machine DifferentSignatures {
 
 ### Type checking
 
-Type checking takes a parse tree and returns a tree of machines. The output type aims at being as strict as possible.
+Type checking takes a parse tree and returns a tree of machines. The output type aims to be as strict as possible.
 
 ### Virtual machine reduction
 
-Virtual machine reduction turns virtual machines into constrained machines. It has no effect on contrained machines.
+Virtual machine reduction turns virtual machines into constrained machines. It has no effect on constrained machines.
 
 #### Inference
 

--- a/analysis/src/block_enforcer.rs
+++ b/analysis/src/block_enforcer.rs
@@ -12,7 +12,7 @@ pub fn enforce<T: FieldElement>(mut file: AnalysisASMFile<T>) -> AnalysisASMFile
             let last_step = "_block_enforcer_last_step";
             let operation_id_no_change = "_operation_id_no_change";
 
-            // add the necessary embedded constraints which apply to both static and dynamic machines
+            // add the necessary embedded constraints that apply to both static and dynamic machines
             let embedded_constraints = [
                 // inject last step
                 parse_pil_statement(&format!("col constant {last_step} = [0]* + [1]")),

--- a/analysis/src/vm/batcher.rs
+++ b/analysis/src/vm/batcher.rs
@@ -27,7 +27,7 @@ impl<'a, T: FieldElement> Batch<'a, T> {
         }
     }
 
-    /// Returns true iff this batch consists exclusively of labels and debug directives
+    /// Returns true if this batch consists exclusively of labels and debug directives
     fn is_only_labels_and_directives(&self) -> bool {
         self.statements.iter().all(|s| {
             matches!(

--- a/analysis/src/vm/mod.rs
+++ b/analysis/src/vm/mod.rs
@@ -1,5 +1,5 @@
 //! Analysis for VM machines, reducing them to constrained machines
-//! Machines which do not have a pc should be left unchanged by this
+//! Machines that do not have a pc should be left unchanged by this
 
 use ast::{asm_analysis::AnalysisASMFile, DiffMonitor};
 use number::FieldElement;

--- a/ast/src/analyzed/mod.rs
+++ b/ast/src/analyzed/mod.rs
@@ -226,7 +226,7 @@ impl<T> Analyzed<T> {
         self.identities.push(Identity {
             id,
             kind: IdentityKind::Polynomial,
-            attribute: None, // TODO(md): None for the meantime as we do not have tagged identities, will be updated in following pr
+            attribute: None, // TODO(md): None for the meantime as we do not have tagged identities, will be updated in the following pr
             source,
             left: SelectedExpressions {
                 selector: Some(identity),

--- a/ast/src/asm_analysis/mod.rs
+++ b/ast/src/asm_analysis/mod.rs
@@ -72,7 +72,7 @@ pub struct Instruction<T> {
 #[derive(Clone, Debug)]
 pub struct LinkDefinitionStatement<T> {
     pub start: usize,
-    /// the flag which activates this link. Should be boolean.
+    /// the flag that activates this link. Should be boolean.
     pub flag: Expression<T>,
     /// the parameters to pass to the callable
     pub params: Params<T>,

--- a/backend/src/pilstark/json_exporter/expression_counter.rs
+++ b/backend/src/pilstark/json_exporter/expression_counter.rs
@@ -36,7 +36,7 @@ pub fn compute_intermediate_expression_ids<T>(analyzed: &Analyzed<T>) -> HashMap
 }
 
 trait ExpressionCounter {
-    /// Returns the number of (top-level) expression generated for this item.
+    /// Returns the number of (top-level) expressions generated for this item.
     fn expression_count(&self) -> usize;
 }
 


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.