### PR TITLE
remove extern crate as not necessary in the newer version of rust

### DIFF
--- a/riscv/build.rs
+++ b/riscv/build.rs
@@ -4,8 +4,6 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
-extern crate lalrpop;
-
 fn main() {
     build_lalrpop();
     build_instruction_tests();

--- a/riscv/tests/riscv_data/many_chunks.rs
+++ b/riscv/tests/riscv_data/many_chunks.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-extern crate alloc;
+
 use alloc::vec::Vec;
 
 #[no_mangle]

--- a/riscv/tests/riscv_data/sum.rs
+++ b/riscv/tests/riscv_data/sum.rs
@@ -1,6 +1,5 @@
 #![no_std]
 
-extern crate alloc;
 use alloc::vec::Vec;
 
 use runtime::get_prover_input;


### PR DESCRIPTION
remove extern crate as not necessary in the newer version of rust